### PR TITLE
more explicit preemption in parallel test

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.20', '1.21.x' ]
+        go-version: [ '1.20', '1.21.x', '1.22.x' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/group_test.go
+++ b/group_test.go
@@ -2,10 +2,10 @@ package parallel
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -148,9 +148,9 @@ func testLimitedGroupMaxConcurrency(t *testing.T, name string, g Executor, limit
 		// All the workers we *expect* to see have shown up now. Throw away all
 		// the poison pills in the ops queue
 		for poisonPill := range g.(*limitedGroup).ops {
-			time.Sleep(0) // Trigger preemption as much as we can
+			runtime.Gosched() // Trigger preemption as much as we can
 			assert.NotNil(t, poisonPill)
-			time.Sleep(0) // Trigger preemption as much as we can
+			runtime.Gosched() // Trigger preemption as much as we can
 		}
 		blocker.Done() // unblock the workers
 		if shouldSucceed {


### PR DESCRIPTION
something changed in the github ci runner and some of these trickier tests are failing in ways that aren't replicating locally.