### PR TITLE
Fix concurrent waiting

### DIFF
--- a/group.go
+++ b/group.go
@@ -95,7 +95,7 @@ func (n *runner) Go(op func(context.Context)) {
 }
 
 func (n *runner) Wait() {
-	n.awaited.Swap(true)
+	n.awaited.Store(true)
 }
 
 func (n *runner) getContext() (context.Context, context.CancelCauseFunc) {
@@ -146,9 +146,8 @@ func (g *group) Go(op func(context.Context)) {
 }
 
 func (g *group) Wait() {
-	if !g.awaited.Swap(true) {
-		g.wg.Wait()
-	}
+	g.awaited.Store(true)
+	g.wg.Wait()
 	g.checkPanic()
 }
 


### PR DESCRIPTION
When `Wait()` is called concurrently, only the first call will actually wait until the work is done. This rarely shows up for most use cases but it completely closes off some uses and there's no good reason for it to work this way.

We add a test that breaks in the old behavior and then provide a simple fix (always unconditionally wait for the underlying `WaitGroup`).