### PR TITLE
context cancelation

### DIFF
--- a/cleanupsdemo/cleanups_demo.go
+++ b/cleanupsdemo/cleanups_demo.go
@@ -26,10 +26,20 @@ func main() {
 
 	println("leaking goroutines from group executors...")
 
-	// Dependent contexts are always canceled, too
+	// Dependent contexts are always canceled, too.
+	//
+	// This binary generally tests that executors and collectors always clean up
+	// after themselves, that any extra goroutines and channels and contexts
+	// they open will be shut down. The easiest thing we can measure is running
+	// goroutines, so to measure things that aren't goroutines (like unclosed
+	// contexts) we can just start new goroutines that wait for contexts we
+	// expect to be canceled.
 	leakDependent := func(ctx context.Context) {
+		// All canceleable child contexts are also canceled
 		ctx, cancel := context.WithCancel(ctx)
 		_ = cancel
+		// Leak a goroutine whose halting depends on the given context being
+		// canceled.
 		go func() {
 			<-ctx.Done()
 		}()

--- a/cleanupsdemo/cleanups_demo.go
+++ b/cleanupsdemo/cleanups_demo.go
@@ -13,6 +13,8 @@ func main() {
 	const cycles = 100
 	const batchSize = 100
 
+	ctx := context.Background()
+
 	// This demonstrates the library's cleanup functionality, where forgotten
 	// executors that own goroutines and have been discarded without being awaited
 	// will clean themselves up without permanently leaking goroutines. This is
@@ -22,14 +24,24 @@ func main() {
 	// of the thunks that are registered with `runtime.SetFinalizer()` in
 	// group.go and collect.go, which close channels and call cancel functions.
 
-	println("leaking ~", cycles*(batchSize+2), "goroutines from abandoned group executors...")
+	println("leaking goroutines from group executors...")
+
+	// Dependent contexts are always canceled, too
+	leakDependent := func(ctx context.Context) {
+		ctx, cancel := context.WithCancel(ctx)
+		_ = cancel
+		go func() {
+			<-ctx.Done()
+		}()
+	}
 
 	// Leak just a crazy number of goroutines
 	for i := 0; i < cycles; i++ {
 		func() {
-			g := parallel.Collect[int](parallel.Limited(context.Background(), batchSize))
+			g := parallel.Collect[int](parallel.Limited(ctx, batchSize))
 			for j := 0; j < batchSize; j++ {
-				g.Go(func(context.Context) (int, error) {
+				g.Go(func(ctx context.Context) (int, error) {
+					leakDependent(ctx)
 					return 1, nil
 				})
 			}
@@ -38,10 +50,11 @@ func main() {
 
 		func() {
 			defer func() { _ = recover() }()
-			g := parallel.Feed(parallel.Unlimited(context.Background()), func(context.Context, int) error {
+			g := parallel.Feed(parallel.Unlimited(ctx), func(context.Context, int) error {
 				panic("feed function panics")
 			})
-			g.Go(func(context.Context) (int, error) {
+			g.Go(func(ctx context.Context) (int, error) {
+				leakDependent(ctx)
 				return 1, nil
 			})
 			// Leak the group without awaiting it
@@ -49,12 +62,45 @@ func main() {
 
 		func() {
 			defer func() { _ = recover() }()
-			g := parallel.Collect[int](parallel.Unlimited(context.Background()))
-			g.Go(func(context.Context) (int, error) {
+			g := parallel.Collect[int](parallel.Unlimited(ctx))
+			g.Go(func(ctx context.Context) (int, error) {
+				leakDependent(ctx)
 				panic("op panics")
 			})
 			// Leak the group without awaiting it
 		}()
+
+		// Start some executors that complete normally without error
+		{
+			g := parallel.Unlimited(ctx)
+			g.Go(func(ctx context.Context) {
+				leakDependent(ctx)
+			})
+			g.Wait()
+		}
+		{
+			g := parallel.Collect[int](parallel.Limited(ctx, batchSize))
+			g.Go(func(ctx context.Context) (int, error) {
+				return 1, nil
+			})
+			_, err := g.Wait()
+			if err != nil {
+				panic(err)
+			}
+		}
+		{
+			g := parallel.Feed(parallel.Unlimited(ctx), func(context.Context, int) error {
+				return nil
+			})
+			g.Go(func(ctx context.Context) (int, error) {
+				leakDependent(ctx)
+				return 1, nil
+			})
+			err := g.Wait()
+			if err != nil {
+				panic(err)
+			}
+		}
 	}
 
 	println("monitoring and running GC...")

--- a/cleanupsdemo/cleanups_demo.go
+++ b/cleanupsdemo/cleanups_demo.go
@@ -88,6 +88,7 @@ func main() {
 		{
 			g := parallel.Collect[int](parallel.Limited(ctx, batchSize))
 			g.Go(func(ctx context.Context) (int, error) {
+				leakDependent(ctx)
 				return 1, nil
 			})
 			_, err := g.Wait()

--- a/cleanupsdemo/cleanups_demo.go
+++ b/cleanupsdemo/cleanups_demo.go
@@ -79,6 +79,13 @@ func main() {
 			g.Wait()
 		}
 		{
+			g := parallel.Limited(ctx, 0)
+			g.Go(func(ctx context.Context) {
+				leakDependent(ctx)
+			})
+			g.Wait()
+		}
+		{
 			g := parallel.Collect[int](parallel.Limited(ctx, batchSize))
 			g.Go(func(ctx context.Context) (int, error) {
 				return 1, nil

--- a/collect.go
+++ b/collect.go
@@ -227,6 +227,10 @@ func FeedWithErrs[T any](executor Executor, receiver func(context.Context, T) er
 // was errGroupDone, that doesn't count as an error and nil is returned instead.
 func groupError(ctx context.Context) error {
 	err := context.Cause(ctx)
+	// We are explicitly using == here to check for the exact value of our
+	// sentinel error, not using errors.Is(), because we don't actually want to
+	// find it if it's in wrapped errors. We *only* want to know whether the
+	// cancelation error is *exactly* errGroupDone.
 	if err == errGroupDone {
 		return nil
 	}

--- a/collect.go
+++ b/collect.go
@@ -310,8 +310,9 @@ func (pg *pipeGroup[T, R]) doWait() {
 				runtime.SetFinalizer(pg, nil)
 			}
 		}()
-		// Runs first: Wait for inputs
-		pg.g.Wait()
+		// Runs first: Wait for inputs. Wait "quietly", not canceling the
+		// context yet so if there is an error later we can still see it
+		pg.g.quietWait()
 	}()
 	// Runs third: Wait for outputs to be done
 	pg.pipeWorkers.Wait()

--- a/group.go
+++ b/group.go
@@ -97,7 +97,6 @@ func Limited(ctx context.Context, maxGoroutines int) Executor {
 	}
 	runtime.SetFinalizer(making, func(doomed *limitedGroup) {
 		close(doomed.ops)
-		doomed.g.cancel(errGroupAbandoned)
 	})
 	return making
 }

--- a/group_test.go
+++ b/group_test.go
@@ -8,7 +8,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type contextLeak struct {
+	lock sync.Mutex
+	ctxs []context.Context
+}
+
+func (c *contextLeak) leak(ctx context.Context) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.ctxs = append(c.ctxs, ctx)
+}
+
+func (c *contextLeak) assertAllCanceled(t *testing.T, expected ...error) {
+	t.Helper()
+	if len(expected) > 1 {
+		panic("please just provide 1 expected error for all the contexts")
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for _, ctx := range c.ctxs {
+		cause := context.Cause(ctx)
+		if cause == nil {
+			t.Fatal("context was not canceled")
+		}
+		if len(expected) == 1 {
+			require.ErrorIs(t, cause, expected[0])
+		}
+	}
+}
 
 func TestGroup(t *testing.T) {
 	for _, test := range []struct {
@@ -43,14 +73,17 @@ func testGroup(t *testing.T, makeExec func(context.Context) Executor) {
 	t.Run("sum 100", func(t *testing.T) {
 		t.Parallel()
 		var counter int64
+		var leak contextLeak
 		g := makeExec(context.Background())
 		for i := 0; i < 100; i++ {
-			g.Go(func(context.Context) {
+			g.Go(func(ctx context.Context) {
+				leak.leak(ctx)
 				atomic.AddInt64(&counter, 1)
 			})
 		}
 		g.Wait()
 		assert.Equal(t, int64(100), counter)
+		leak.assertAllCanceled(t, errGroupDone)
 	})
 	t.Run("sum canceled", func(t *testing.T) {
 		t.Parallel()

--- a/safety_test.go
+++ b/safety_test.go
@@ -97,7 +97,8 @@ func TestCollectorCleanup(t *testing.T) {
 	for range valuePipe {
 		// The channel should get closed!
 	}
-	leak.assertAllCanceled(t) // the cancelation error is inconsistent here
+	leak.assertAllCanceled(t) // the cancelation error is inconsistent here,
+	// depending on whether the pipe group or the executor was reaped first
 }
 
 func TestFeederCleanup(t *testing.T) {
@@ -119,7 +120,8 @@ func TestFeederCleanup(t *testing.T) {
 	for range valuePipe {
 		// The channel should get closed!
 	}
-	leak.assertAllCanceled(t) // the cancelation error is inconsistent here
+	leak.assertAllCanceled(t) // the cancelation error is inconsistent here,
+	// depending on whether the pipe group or the executor was reaped first
 }
 
 func TestGatherErrCleanup(t *testing.T) {
@@ -141,7 +143,8 @@ func TestGatherErrCleanup(t *testing.T) {
 	for range valuePipe {
 		// The channel should get closed!
 	}
-	leak.assertAllCanceled(t) // the cancelation error is inconsistent here
+	leak.assertAllCanceled(t) // the cancelation error is inconsistent here,
+	// depending on whether the pipe group or the executor was reaped first
 }
 
 func TestCollectWithErrsCleanup(t *testing.T) {
@@ -163,7 +166,8 @@ func TestCollectWithErrsCleanup(t *testing.T) {
 	for range valuePipe {
 		// The channel should get closed!
 	}
-	leak.assertAllCanceled(t) // the cancelation error is inconsistent here
+	leak.assertAllCanceled(t) // the cancelation error is inconsistent here,
+	// depending on whether the pipe group or the executor was reaped first
 }
 
 func TestFeedWithErrsCleanup(t *testing.T) {
@@ -186,7 +190,8 @@ func TestFeedWithErrsCleanup(t *testing.T) {
 	for range valuePipe {
 		// The channel should get closed!
 	}
-	leak.assertAllCanceled(t) // the cancelation error is inconsistent here
+	leak.assertAllCanceled(t) // the cancelation error is inconsistent here,
+	// depending on whether the pipe group or the executor was reaped first
 }
 
 func TestPanicGroup(t *testing.T) {
@@ -303,7 +308,7 @@ func TestPanicFeedFunction(t *testing.T) {
 		return 1, nil
 	})
 	assertPanicsWithValue(t, "oh no!", func() { _ = g.Wait() })
-	leak.assertAllCanceled(t) // the cancelation error is inconsistent here
+	leak.assertAllCanceled(t, errPanicked)
 }
 
 func TestPanicFeedWork(t *testing.T) {
@@ -369,7 +374,7 @@ func TestPanicFeedErrFunction(t *testing.T) {
 		return 1, nil
 	})
 	assertPanicsWithValue(t, "oh no!", func() { _ = g.Wait() })
-	leak.assertAllCanceled(t) // the cancelation error is inconsistent here
+	leak.assertAllCanceled(t, errPanicked)
 }
 
 func TestPanicFeedErrWork(t *testing.T) {

--- a/safety_test.go
+++ b/safety_test.go
@@ -70,6 +70,8 @@ func TestTrivialGroupCleanup(t *testing.T) {
 		}
 	}()
 	runtime.GC() // Trigger cleanups for leaked resources
+	runtime.GC() // Trigger cleanups for leaked resources
+	runtime.GC() // Trigger cleanups for leaked resources
 	assert.Equal(t, int64(100), counter)
 	// The context should be canceled!
 	leak.assertAllCanceled(t, errGroupAbandoned)

--- a/safety_test.go
+++ b/safety_test.go
@@ -525,6 +525,8 @@ func TestForgottenPipeLegiblePanic(t *testing.T) {
 	}()
 	assert.NotNil(t, valuePipe)
 	runtime.GC() // Trigger cleanups for leaked resources
+	runtime.GC() // Trigger cleanups for leaked resources
+	runtime.GC() // Trigger cleanups for leaked resources
 	for range valuePipe {
 	}
 	// The collector's pipe is now closed. Unblock the task we submitted to the


### PR DESCRIPTION
`parallel` creates `WithCancelContext` subcontexts for its executors; until now, there has been no guarantee that these child contexts will be canceled.

Under most circumstances this has unremarkable effects, but when there are long-running cancelable parent contexts things can get very nasty. Creating a cancelable context under another cancelable context registers the new context as a child underneath the parent, and it is not unregistered until it is canceled; it will stay alive, reachable, and never be garbage collected as long as the parent context remains alive. This is the reason for the common pattern (present in a now notoriously unreliable `go vet` lint) to immediately `defer cancel()`.

This change should introduce guarantees that the lifetimes of `parallel` executors' contexts should not greatly outlive the executors themselves. If the executors are abandoned they will be automatically canceled, and if the executors are awaited they are canceled immediately, either at the first terminating error or when all work has completed.