### PR TITLE
Panic pretty printing

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,6 @@ linters:
     - typecheck
     - unused
     - gci
-    - exportloopref
 linters-settings:
   goimports:
     local-prefixes: "github.com/wandb/parallel"

--- a/collect.go
+++ b/collect.go
@@ -324,10 +324,10 @@ func (pg *pipeGroup[T, R]) doWait() {
 		}()
 		// Runs first: Wait for inputs. Wait "quietly", not canceling the
 		// context yet so if there is an error later we can still see it
-		pg.g.quietWait()
+		pg.g.waitWithoutCanceling()
 	}()
 	// Runs third: Wait for outputs to be done
-	pg.pipeWorkers.quietWait()
+	pg.pipeWorkers.waitWithoutCanceling()
 }
 
 var _ CollectingExecutor[int] = collectingGroup[int]{}

--- a/group.go
+++ b/group.go
@@ -31,7 +31,7 @@ var (
 
 // WorkerPanic represents a panic value propagated from a task within a parallel
 // executor, and is the main type of panic that you might expect to receive.
-type WorkerPanic struct {
+type WorkerPanic struct { //nolint:errname
 	// Panic contains the originally panic()ed value.
 	Panic any
 	// Stacktraces contains the stacktraces of the panics. The stack trace of

--- a/group.go
+++ b/group.go
@@ -3,8 +3,10 @@ package parallel
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -37,6 +39,21 @@ type WorkerPanic struct {
 	// stack traces from other parallel groups that received this panic and re-
 	// threw it appear in order afterwards.
 	Stacktraces []string
+}
+
+// We pretty-print our wrapped panic type including the captured stack traces.
+func (wp WorkerPanic) Error() string {
+	var sb strings.Builder
+	for _, s := range wp.Stacktraces {
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+	}
+	return fmt.Sprintf(
+		"%#v\n\nPrior %d executor stack trace(s), innermost first:\n%s",
+		wp.Panic,
+		len(wp.Stacktraces),
+		sb.String(),
+	)
 }
 
 // NOTE: If you want to really get crazy with it, it IS permissible and safe to

--- a/panic_demo/panic_demo.go
+++ b/panic_demo/panic_demo.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"github.com/wandb/parallel"
+)
+
+func main() {
+	g := parallel.Unlimited(context.Background())
+	g.Go(bear)
+	g.Wait()
+}
+
+func bear(_ context.Context) {
+	g := parallel.Unlimited(context.Background())
+	g.Go(foo)
+	g.Wait()
+}
+
+func foo(_ context.Context) {
+	bar()
+}
+
+func bar() {
+	panic("baz")
+}

--- a/panic_demo/panic_demo.go
+++ b/panic_demo/panic_demo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+
 	"github.com/wandb/parallel"
 )
 


### PR DESCRIPTION
It looks like the go runtime uses the `error` interface to opportunistically pretty-print panicked values, so we can use that to make propagated panics look much nicer.

```
$ go run ./panic_demo/
panic: "baz"

Prior 2 executor stack trace(s), innermost first:
goroutine 7 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:24 +0x5e
github.com/wandb/parallel.(*group).Go.func1.1()
        /home/widders/repos/parallel/group.go:229 +0x1ed
panic({0x498ce0?, 0x4d1250?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
main.bar(...)
        /home/widders/repos/parallel/panic_demo/panic_demo.go:25
main.foo({0x0?, 0x0?})
        /home/widders/repos/parallel/panic_demo/panic_demo.go:21 +0x25
github.com/wandb/parallel.(*group).Go.func1()
        /home/widders/repos/parallel/group.go:239 +0x70
created by github.com/wandb/parallel.(*group).Go in goroutine 6
        /home/widders/repos/parallel/group.go:201 +0xb7

goroutine 6 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:24 +0x5e
github.com/wandb/parallel.(*group).Go.func1.1()
        /home/widders/repos/parallel/group.go:224 +0xbc
panic({0x4a2aa0?, 0xc0000be0c0?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
github.com/wandb/parallel.(*group).checkPanic(...)
        /home/widders/repos/parallel/group.go:259
github.com/wandb/parallel.(*group).quietWait(0xc0000c0080)
        /home/widders/repos/parallel/group.go:253 +0x75
github.com/wandb/parallel.(*group).Wait(0xc0000c0080?)
        /home/widders/repos/parallel/group.go:246 +0x6b
main.bear({0x0?, 0x0?})
        /home/widders/repos/parallel/panic_demo/panic_demo.go:17 +0x4f
github.com/wandb/parallel.(*group).Go.func1()
        /home/widders/repos/parallel/group.go:239 +0x70
created by github.com/wandb/parallel.(*group).Go in goroutine 1
        /home/widders/repos/parallel/group.go:201 +0xb7



goroutine 1 [running]:
github.com/wandb/parallel.(*group).checkPanic(...)
        /home/widders/repos/parallel/group.go:259
github.com/wandb/parallel.(*group).quietWait(0xc0000c0040)
        /home/widders/repos/parallel/group.go:253 +0x75
github.com/wandb/parallel.(*group).Wait(0xc0000c0040?)
        /home/widders/repos/parallel/group.go:246 +0x6b
main.main()
        /home/widders/repos/parallel/panic_demo/panic_demo.go:11 +0x4f
exit status 2
```